### PR TITLE
fix(ci): correct Dockerfile dependency installation

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -11,14 +11,7 @@ COPY package.json package-lock.json ./
 COPY apps/web/package.json ./apps/web/
 COPY libs/database/package.json ./libs/database/
 
-# Install root dependencies
-RUN npm ci --only=production --legacy-peer-deps
-
-# Install workspace dependencies
-WORKDIR /app/apps/web
-RUN npm ci --only=production --legacy-peer-deps
-
-WORKDIR /app/libs/database
+# Install dependencies
 RUN npm ci --only=production --legacy-peer-deps
 
 # Stage 2: Builder
@@ -32,10 +25,6 @@ COPY libs/database/package.json ./libs/database/
 COPY tsconfig.base.json ./
 
 # Install all dependencies (including dev)
-RUN npm ci --legacy-peer-deps
-WORKDIR /app/apps/web
-RUN npm ci --legacy-peer-deps
-WORKDIR /app/libs/database
 RUN npm ci --legacy-peer-deps
 
 # Copy ALL source code (must happen after npm ci for workspaces)


### PR DESCRIPTION
Corrects the Docker build failure by replacing multiple `npm ci` commands with a single command at the monorepo root. This ensures all dependencies are installed correctly before the build.