### PR TITLE
feat(security): add audit logging for sensitive actions (ST-206)

### DIFF
--- a/apps/web/src/app/account/privacy/request-client.tsx
+++ b/apps/web/src/app/account/privacy/request-client.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+// cspell:ignore anchorpipe
+
 import { useState } from 'react';
 
 type SerializedRequest = {

--- a/apps/web/src/app/api/audit-logs/route.ts
+++ b/apps/web/src/app/api/audit-logs/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { readSession } from '@/lib/auth';
+import { listAuditLogs } from '@/lib/audit-service';
+import { userHasAdminRole } from '@/lib/rbac-service';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  try {
+    const session = await readSession();
+    const userId = session?.sub as string | undefined;
+
+    if (!userId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const isAdmin = await userHasAdminRole(userId);
+    if (!isAdmin) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    const searchParams = request.nextUrl.searchParams;
+    const subject = searchParams.get('subject') ?? undefined;
+    const actorId = searchParams.get('actorId') ?? undefined;
+    const cursor = searchParams.get('cursor') ?? undefined;
+    const limitParam = searchParams.get('limit');
+    const limit = limitParam ? Math.min(Math.max(parseInt(limitParam, 10) || 50, 1), 200) : 50;
+
+    const logs = await listAuditLogs({
+      limit,
+      subject: subject as any,
+      actorId: actorId ?? undefined,
+      cursor: cursor ?? undefined,
+    });
+
+    return NextResponse.json({ data: logs });
+  } catch (error) {
+    console.error('Failed to list audit logs', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/api/dsr/export/[requestId]/route.ts
+++ b/apps/web/src/app/api/dsr/export/[requestId]/route.ts
@@ -1,6 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getExportPayload } from '@/lib/dsr-service';
 import { readSession } from '@/lib/auth';
+import {
+  AUDIT_ACTIONS,
+  AUDIT_SUBJECTS,
+  extractRequestContext,
+  writeAuditLog,
+} from '@/lib/audit-service';
+
+export const dynamic = 'force-dynamic';
 
 export async function GET(
   request: NextRequest,
@@ -16,6 +24,21 @@ export async function GET(
 
     const { requestId } = await params;
     const payload = await getExportPayload(userId, requestId);
+
+    const context = extractRequestContext(request);
+
+    await writeAuditLog({
+      actorId: userId,
+      action: AUDIT_ACTIONS.dsrExportDownload,
+      subject: AUDIT_SUBJECTS.dsr,
+      subjectId: requestId,
+      description: 'User downloaded data export.',
+      metadata: {
+        sizeBytes: JSON.stringify(payload).length,
+      },
+      ipAddress: context.ipAddress,
+      userAgent: context.userAgent,
+    });
 
     return new NextResponse(JSON.stringify(payload, null, 2), {
       headers: {

--- a/apps/web/src/app/api/dsr/export/route.ts
+++ b/apps/web/src/app/api/dsr/export/route.ts
@@ -1,8 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { requestDataExport } from '@/lib/dsr-service';
 import { readSession } from '@/lib/auth';
+import { extractRequestContext } from '@/lib/audit-service';
 
-export async function POST(_request: NextRequest) {
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: NextRequest) {
   try {
     const session = await readSession();
     const userId = session?.sub as string | undefined;
@@ -11,7 +14,7 @@ export async function POST(_request: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const dsr = await requestDataExport(userId);
+    const dsr = await requestDataExport(userId, extractRequestContext(request));
 
     return NextResponse.json({
       requestId: dsr.id,

--- a/apps/web/src/app/api/dsr/route.ts
+++ b/apps/web/src/app/api/dsr/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { listDataSubjectRequests } from '@/lib/dsr-service';
 import { readSession } from '@/lib/auth';
 
+export const dynamic = 'force-dynamic';
+
 export async function GET(_request: NextRequest) {
   try {
     const session = await readSession();

--- a/apps/web/src/app/api/repos/[repoId]/roles/route.ts
+++ b/apps/web/src/app/api/repos/[repoId]/roles/route.ts
@@ -4,6 +4,9 @@ import { requireAuthz } from '@/lib/authz';
 import { assignRole, removeRole, getRepoUsers } from '@/lib/rbac-service';
 import { RepoRole } from '@/lib/rbac';
 import { validateRequest } from '@/lib/validation';
+import { extractRequestContext } from '@/lib/audit-service';
+
+export const dynamic = 'force-dynamic';
 
 const assignRoleSchema = z.object({
   userId: z.string().uuid(),
@@ -66,7 +69,7 @@ export async function POST(
     }
 
     const { userId, role } = validation.data;
-    await assignRole(context.userId, userId, repoId, role);
+    await assignRole(context.userId, userId, repoId, role, extractRequestContext(request));
 
     return NextResponse.json({
       message: 'Role assigned successfully',
@@ -109,7 +112,7 @@ export async function DELETE(
     }
 
     const { userId } = validation.data;
-    await removeRole(context.userId, userId, repoId);
+    await removeRole(context.userId, userId, repoId, extractRequestContext(request));
 
     return NextResponse.json({
       message: 'Role removed successfully',

--- a/apps/web/src/lib/audit-service.test.ts
+++ b/apps/web/src/lib/audit-service.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { listAuditLogs, writeAuditLog, AUDIT_ACTIONS, AUDIT_SUBJECTS } from './audit-service';
+
+vi.mock('@anchorpipe/database', () => {
+  const mockPrisma = {
+    auditLog: {
+      create: vi.fn(),
+      findMany: vi.fn(),
+    },
+  };
+
+  return {
+    prisma: mockPrisma,
+  };
+});
+
+describe('audit-service', () => {
+  let prismaMock: any;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const { prisma } = await import('@anchorpipe/database');
+    prismaMock = prisma as any;
+  });
+
+  describe('writeAuditLog', () => {
+    it('creates audit log with sanitized metadata', async () => {
+      const longMetadata = { notes: 'a'.repeat(5000) };
+
+      await writeAuditLog({
+        actorId: 'user-1',
+        action: AUDIT_ACTIONS.loginSuccess,
+        subject: AUDIT_SUBJECTS.user,
+        subjectId: 'user-1',
+        description: 'User logged in.',
+        metadata: longMetadata,
+        ipAddress: '203.0.113.42',
+        userAgent: 'Vitest',
+      });
+
+      expect(prismaMock.auditLog.create).toHaveBeenCalled();
+      const call = prismaMock.auditLog.create.mock.calls[0][0];
+      expect(call.data.actorId).toBe('user-1');
+      expect(call.data.metadata).toEqual({
+        truncated: true,
+        note: 'Metadata exceeded storage limit',
+      });
+      expect(call.data.ipAddress).toBe('203.0.113.42');
+      expect(call.data.userAgent).toBe('Vitest');
+    });
+  });
+
+  describe('listAuditLogs', () => {
+    it('returns audit logs ordered by createdAt', async () => {
+      prismaMock.auditLog.findMany.mockResolvedValue([
+        {
+          id: 'log-1',
+          action: 'role_assigned',
+          subject: 'repo',
+          subjectId: 'repo-1',
+          description: 'Assigned role',
+          metadata: { targetUserId: 'user-1' },
+          ipAddress: '203.0.113.1',
+          userAgent: 'test',
+          createdAt: new Date(),
+          actor: { id: 'admin-1', email: 'admin@example.com', githubLogin: 'admin', name: 'Admin' },
+        },
+      ]);
+
+      const logs = await listAuditLogs({ limit: 10, subject: AUDIT_SUBJECTS.repo });
+
+      expect(prismaMock.auditLog.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { subject: AUDIT_SUBJECTS.repo },
+          take: 10,
+          orderBy: { createdAt: 'desc' },
+        })
+      );
+      expect(logs).toHaveLength(1);
+      expect(logs[0].action).toBe('role_assigned');
+      expect(logs[0].actor?.email).toBe('admin@example.com');
+    });
+  });
+});

--- a/apps/web/src/lib/audit-service.ts
+++ b/apps/web/src/lib/audit-service.ts
@@ -1,0 +1,162 @@
+import { prisma } from '@anchorpipe/database';
+import type { NextRequest } from 'next/server';
+
+const prismaWithAudit = prisma as any;
+
+export const AUDIT_ACTIONS = {
+  loginSuccess: 'login_success',
+  loginFailure: 'login_failure',
+  userCreated: 'user_created',
+  roleAssigned: 'role_assigned',
+  roleRemoved: 'role_removed',
+  dsrExportRequest: 'dsr_export_request',
+  dsrExportDownload: 'dsr_export_download',
+  dsrDeletionRequest: 'dsr_deletion_request',
+  configUpdated: 'config_updated',
+  tokenCreated: 'token_created',
+  tokenRevoked: 'token_revoked',
+  other: 'other',
+} as const;
+
+export const AUDIT_SUBJECTS = {
+  user: 'user',
+  repo: 'repo',
+  dsr: 'dsr',
+  configuration: 'configuration',
+  security: 'security',
+  session: 'session',
+  token: 'token',
+  system: 'system',
+} as const;
+
+type AuditAction = (typeof AUDIT_ACTIONS)[keyof typeof AUDIT_ACTIONS];
+type AuditSubject = (typeof AUDIT_SUBJECTS)[keyof typeof AUDIT_SUBJECTS];
+
+export interface AuditLogInput {
+  actorId?: string | null;
+  action: AuditAction;
+  subject: AuditSubject;
+  subjectId?: string | null;
+  description?: string | null;
+  metadata?: Record<string, unknown> | null;
+  ipAddress?: string | null;
+  userAgent?: string | null;
+}
+
+export interface AuditLogQuery {
+  limit?: number;
+  subject?: AuditSubject;
+  actorId?: string;
+  cursor?: string;
+}
+
+export interface RequestContext {
+  ipAddress: string | null;
+  userAgent: string | null;
+}
+
+const MAX_METADATA_LENGTH = 4000;
+const MAX_TEXT_LENGTH = 255;
+
+function sanitizeMetadata(metadata?: Record<string, unknown> | null) {
+  if (!metadata) return null;
+  try {
+    const cleaned = JSON.parse(JSON.stringify(metadata));
+    const serialized = JSON.stringify(cleaned);
+    if (serialized.length > MAX_METADATA_LENGTH) {
+      return {
+        truncated: true,
+        note: 'Metadata exceeded storage limit',
+      };
+    }
+    return cleaned;
+  } catch (error) {
+    console.warn('Failed to sanitize audit metadata', error);
+    return {
+      truncated: true,
+      note: 'Serialization failed',
+    };
+  }
+}
+
+function clampText(value?: string | null, max = MAX_TEXT_LENGTH) {
+  if (!value) return null;
+  return value.length > max ? value.slice(0, max) : value;
+}
+
+export async function writeAuditLog(input: AuditLogInput): Promise<void> {
+  try {
+    await prismaWithAudit.auditLog.create({
+      data: {
+        actorId: input.actorId ?? null,
+        action: input.action,
+        subject: input.subject,
+        subjectId: input.subjectId ?? null,
+        description: clampText(input.description ?? null, 512),
+        metadata: sanitizeMetadata(input.metadata ?? null),
+        ipAddress: clampText(input.ipAddress ?? null, 45),
+        userAgent: clampText(input.userAgent ?? null, 512),
+      },
+    });
+  } catch (error) {
+    console.error('Failed to write audit log', error);
+  }
+}
+
+export async function listAuditLogs(query: AuditLogQuery = {}): Promise<any[]> {
+  const where: Record<string, unknown> = {};
+  if (query.subject) {
+    where.subject = query.subject;
+  }
+  if (query.actorId) {
+    where.actorId = query.actorId;
+  }
+
+  const take = Math.min(Math.max(query.limit ?? 50, 1), 200);
+
+  const logs = await prismaWithAudit.auditLog.findMany({
+    where,
+    orderBy: { createdAt: 'desc' },
+    take,
+    ...(query.cursor
+      ? {
+          cursor: { id: query.cursor },
+          skip: 1,
+        }
+      : {}),
+    include: {
+      actor: {
+        select: {
+          id: true,
+          email: true,
+          githubLogin: true,
+          name: true,
+        },
+      },
+    },
+  });
+
+  return logs.map((log: any) => ({
+    id: log.id,
+    action: log.action,
+    subject: log.subject,
+    subjectId: log.subjectId,
+    description: log.description,
+    metadata: log.metadata,
+    ipAddress: log.ipAddress,
+    userAgent: log.userAgent,
+    createdAt: log.createdAt,
+    actor: log.actor ?? null,
+  }));
+}
+
+export function extractRequestContext(request: NextRequest): RequestContext {
+  const forwarded = request.headers.get('x-forwarded-for');
+  const ipCandidate = forwarded?.split(',')[0]?.trim() || (request as any).ip || null;
+  const userAgent = request.headers.get('user-agent');
+
+  return {
+    ipAddress: ipCandidate ?? null,
+    userAgent: userAgent ?? null,
+  };
+}

--- a/apps/web/src/lib/rbac.ts
+++ b/apps/web/src/lib/rbac.ts
@@ -11,7 +11,7 @@ export enum RepoRole {
 export type PermissionAction = 'read' | 'write' | 'manage' | 'admin';
 
 // Permission subjects
-export type PermissionSubject = 'repo' | 'test_case' | 'test_run' | 'config' | 'role';
+export type PermissionSubject = 'repo' | 'test_case' | 'test_run' | 'config' | 'role' | 'audit';
 
 export type AppAbility = PureAbility<[PermissionAction, PermissionSubject]>;
 
@@ -27,7 +27,7 @@ function defineAbilitiesFor(role: RepoRole | null) {
   switch (role) {
     case RepoRole.ADMIN:
       // Admins can do everything
-      can('read', ['repo', 'test_case', 'test_run', 'config', 'role']);
+      can('read', ['repo', 'test_case', 'test_run', 'config', 'role', 'audit']);
       can('write', ['repo', 'test_case', 'test_run', 'config']);
       can('manage', ['repo', 'test_case', 'test_run', 'config']);
       can('admin', ['role', 'config']);

--- a/docs/SECURITY_AUDIT.md
+++ b/docs/SECURITY_AUDIT.md
@@ -1,0 +1,36 @@
+# Audit Logging (ST-206)
+
+## Overview
+
+Implements comprehensive audit logging for sensitive operations, covering authentication, role management, and data subject request flows. Entries are immutable, timestamped, and queryable via the new `/api/audit-logs` endpoint (admin-only).
+
+## Data Model
+
+- `AuditLog` table with enums `AuditAction` and `AuditSubject`.
+- Stores actor, subject, description, metadata (sanitized), IP address, and user agent.
+- Indexed by `subject/subjectId` and `createdAt` for efficient queries.
+
+## Captured Actions
+
+- `login_success` / `login_failure` (email conflict & invalid attempts).
+- `user_created` (registration).
+- `role_assigned` / `role_removed`.
+- `dsr_export_request`, `dsr_deletion_request`, `dsr_export_download`.
+- Hooks available for future config/token events.
+
+## API
+
+- `GET /api/audit-logs?limit=50&subject=dsr&actorId=...` → returns most recent entries (requires repo admin role).
+- Responses include actor metadata, timestamps, sanitized metadata payload.
+
+## Usage
+
+- `writeAuditLog()` helper sanitizes metadata and clamps text length.
+- `extractRequestContext()` centralizes IP/user agent extraction.
+- Services (`rbac-service`, `dsr-service`, auth routes) call helpers to record events.
+
+## Operations
+
+- No update/delete mutations; audit logs append-only.
+- Monitor suspicious patterns by scanning for repeated `login_failure` entries.
+- Future enhancements: stream to SIEM, add alerting via telemetry events.

--- a/libs/database/prisma/migrations/20251107143000_add_audit_logs/migration.sql
+++ b/libs/database/prisma/migrations/20251107143000_add_audit_logs/migration.sql
@@ -1,0 +1,53 @@
+-- CreateEnum
+CREATE TYPE "AuditAction" AS ENUM (
+    'login_success',
+    'login_failure',
+    'user_created',
+    'role_assigned',
+    'role_removed',
+    'dsr_export_request',
+    'dsr_export_download',
+    'dsr_deletion_request',
+    'config_updated',
+    'token_created',
+    'token_revoked',
+    'other'
+);
+
+-- CreateEnum
+CREATE TYPE "AuditSubject" AS ENUM (
+    'user',
+    'repo',
+    'dsr',
+    'configuration',
+    'security',
+    'session',
+    'token',
+    'system'
+);
+
+-- CreateTable
+CREATE TABLE "audit_logs" (
+    "id" TEXT NOT NULL,
+    "actor_id" TEXT,
+    "action" "AuditAction" NOT NULL,
+    "subject" "AuditSubject" NOT NULL,
+    "subject_id" TEXT,
+    "description" TEXT,
+    "metadata" JSONB,
+    "ip_address" TEXT,
+    "user_agent" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "audit_logs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "audit_logs_subject_subject_id_idx" ON "audit_logs"("subject", "subject_id");
+
+-- CreateIndex
+CREATE INDEX "audit_logs_created_at_idx" ON "audit_logs"("created_at" DESC);
+
+-- AddForeignKey
+ALTER TABLE "audit_logs" ADD CONSTRAINT "audit_logs_actor_id_fkey" FOREIGN KEY ("actor_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+

--- a/libs/database/prisma/schema.prisma
+++ b/libs/database/prisma/schema.prisma
@@ -63,6 +63,7 @@ model User {
   roleAuditLogsAsActor  RoleAuditLog[]       @relation("RoleAuditActor")
   roleAuditLogsAsTarget RoleAuditLog[]       @relation("RoleAuditTarget")
   dataSubjectRequests   DataSubjectRequest[]
+  auditLogs             AuditLog[]           @relation("AuditActor")
 
   @@index([githubId])
   @@map("users")
@@ -380,4 +381,54 @@ model RoleAuditLog {
   @@index([repoId])
   @@index([createdAt(sort: Desc)])
   @@map("role_audit_logs")
+}
+
+// ============================================
+// General Audit Logging
+// ============================================
+
+enum AuditAction {
+  login_success
+  login_failure
+  user_created
+  role_assigned
+  role_removed
+  dsr_export_request
+  dsr_export_download
+  dsr_deletion_request
+  config_updated
+  token_created
+  token_revoked
+  other
+}
+
+enum AuditSubject {
+  user
+  repo
+  dsr
+  configuration
+  security
+  session
+  token
+  system
+}
+
+model AuditLog {
+  id          String       @id @default(uuid())
+  actorId     String?      @map("actor_id")
+  action      AuditAction
+  subject     AuditSubject
+  subjectId   String?      @map("subject_id")
+  description String?
+  metadata    Json?
+  ipAddress   String?      @map("ip_address")
+  userAgent   String?      @map("user_agent")
+  createdAt   DateTime     @default(now()) @map("created_at")
+
+  // Relations
+  actor User? @relation("AuditActor", fields: [actorId], references: [id], onDelete: SetNull)
+
+  @@index([subject, subjectId])
+  @@index([createdAt])
+  @@map("audit_logs")
 }


### PR DESCRIPTION
## 🎯 Implementation Summary

Delivers **ST-206: Implement Audit Logging for Sensitive Actions**, introducing a reusable audit log schema, service utilities, and API endpoints that capture auth, RBAC, and data-subject request events.

## ✅ Acceptance Criteria Met

### Scenario 1: Audit capture for sensitive actions
- ✅ Login/register routes record success/failure entries with IP + UA metadata.
- ✅ RBAC role assignment/removal writes structured audit entries alongside existing role audit table.
- ✅ DSR export/deletion workflows emit audit logs covering request + completion.

### Scenario 2: Immutability and retention
- ✅ `audit_logs` table (Prisma model + migration) persists entries with indexed timestamp + subject filters.
- ✅ Records capture actor linkage (FK to `users`) and store normalized JSON metadata.

### Scenario 3: Querying and monitoring
- ✅ `GET /api/audit-logs` endpoint (admin-restricted) exposes paginated audit history with filtering.
- ✅ New `audit-service` module offers `writeAuditLog`, `listAuditLogs`, and request-context extraction for reuse.

## 📦 What's Included

### Database
- `AuditLog` model + enums (`AuditAction`, `AuditSubject`) and migration `20251107143000_add_audit_logs`.

### Backend
- `audit-service.ts` + tests (`audit-service.test.ts`).
- Updates to auth, RBAC, and DSR services/routes to emit audit logs.
- `GET /api/audit-logs` route for admin review.

### Docs
- `docs/SECURITY_AUDIT.md` covering coverage areas, actions, and operational notes.

## 🧪 Testing

```bash
# prisma client
npm run db:generate

# repo root
npm run lint
npm run build

# web workspace
npm run test -- @anchorpipe/web:test
npm run type-check --workspace=@anchorpipe/web
```

Vitest suite includes new `audit-service.test.ts` coverage; RBAC and DSR tests updated to assert audit writes.

## 📋 Checklist
- [x] Schema/migration and Prisma client updated
- [x] Sensitive flows instrumented with audit logging
- [x] API + docs added for querying audit history
- [x] Tests, lint, typecheck, build all green locally

## 🔗 Related
- Implements ST-206 (Security Foundation GA)
- Builds on ST-201/202/205 to complete security/audit coverage

