### PR TITLE
🔐 fix: enforce npm toolchain patch & deps

### DIFF
--- a/libs/database/package.json
+++ b/libs/database/package.json
@@ -14,13 +14,13 @@
     "db:health": "tsx src/health-check.ts"
   },
   "dependencies": {
-    "@prisma/client": "^7.0.0",
-    "@prisma/adapter-pg": "^7.0.0",
+    "@prisma/client": "^7.0.1",
+    "@prisma/adapter-pg": "^7.0.1",
     "pg": "^8.13.1"
   },
   "devDependencies": {
     "@types/pg": "^8.11.10",
-    "prisma": "^7.0.0",
+    "prisma": "^7.0.1",
     "tsx": "^4.19.0",
     "typescript": "^5.7.2"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@nx/node": "^22.1.1",
         "@nx/vite": "22.1.1",
         "@nx/web": "22.1.1",
-        "@prisma/client": "^7.0.0",
+        "@prisma/client": "^7.0.1",
         "@swc-node/register": "~1.11.1",
         "@swc/core": "~1.15.3",
         "@swc/helpers": "~0.5.11",
@@ -37,7 +37,7 @@
         "jsonc-eslint-parser": "^2.1.0",
         "nx": "^22.0.2",
         "prettier": "^3.3.2",
-        "prisma": "^7.0.0",
+        "prisma": "^7.0.1",
         "swagger-cli": "^4.0.4",
         "tslib": "^2.3.0",
         "typescript": "^5.6.2",
@@ -250,13 +250,13 @@
       "name": "@anchorpipe/database",
       "version": "0.1.0",
       "dependencies": {
-        "@prisma/adapter-pg": "^7.0.0",
-        "@prisma/client": "^7.0.0",
+        "@prisma/adapter-pg": "^7.0.1",
+        "@prisma/client": "^7.0.1",
         "pg": "^8.13.1"
       },
       "devDependencies": {
         "@types/pg": "^8.11.10",
-        "prisma": "^7.0.0",
+        "prisma": "^7.0.1",
         "tsx": "^4.19.0",
         "typescript": "^5.7.2"
       }
@@ -7135,22 +7135,22 @@
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/dev": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@prisma/dev/-/dev-0.13.0.tgz",
-      "integrity": "sha512-QMmF6zFeUF78yv1HYbHvod83AQnl7u6NtKyDhTRZOJup3h1icWs8R7RUVxBJZvM2tBXNAMpLQYYM/8kPlOPegA==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@prisma/dev/-/dev-0.14.0.tgz",
+      "integrity": "sha512-pjzRGwreN8z0ln1BkubzAJpoAGeK4As1hGiCRJQTpFU3O003jtRWGdb9xZAaHrp4RlJBdBsJbfF4HOV7AEkjvQ==",
       "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "@electric-sql/pglite": "0.3.2",
         "@electric-sql/pglite-socket": "0.0.6",
         "@electric-sql/pglite-tools": "0.2.7",
-        "@hono/node-server": "1.14.2",
+        "@hono/node-server": "1.19.6",
         "@mrleebo/prisma-ast": "0.12.1",
         "@prisma/get-platform": "6.8.2",
         "@prisma/query-plan-executor": "6.18.0",
         "foreground-child": "3.3.1",
         "get-port-please": "3.1.2",
-        "hono": "4.7.10",
+        "hono": "4.10.6",
         "http-status-codes": "2.3.0",
         "pathe": "2.0.3",
         "proper-lockfile": "4.1.2",
@@ -27725,9 +27725,9 @@
       }
     },
     "node_modules/valibot": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.1.0.tgz",
-      "integrity": "sha512-Nk8lX30Qhu+9txPYTwM0cFlWLdPFsFr6LblzqIySfbZph9+BFsAHsNvHOymEviUepeIW6KFHzpX8TKhbptBXXw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.2.0.tgz",
+      "integrity": "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==",
       "devOptional": true,
       "license": "MIT",
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@nx/node": "^22.1.1",
     "@nx/vite": "22.1.1",
     "@nx/web": "22.1.1",
-    "@prisma/client": "^7.0.0",
+    "@prisma/client": "^7.0.1",
     "@swc-node/register": "~1.11.1",
     "@swc/core": "~1.15.3",
     "@swc/helpers": "~0.5.11",
@@ -48,7 +48,7 @@
     "jsonc-eslint-parser": "^2.1.0",
     "nx": "^22.0.2",
     "prettier": "^3.3.2",
-    "prisma": "^7.0.0",
+    "prisma": "^7.0.1",
     "swagger-cli": "^4.0.4",
     "tslib": "^2.3.0",
     "typescript": "^5.6.2",
@@ -64,7 +64,9 @@
     "@typescript-eslint/parser": "^6.21.0",
     "hono": "^4.10.3",
     "@hono/node-server": "^1.15.0",
-    "tmp": "^0.2.4"
+    "tmp": "^0.2.4",
+    "@prisma/dev": "0.14.0",
+    "valibot": "1.2.0"
   },
   "dependencies": {
     "ioredis": "^5.8.2",


### PR DESCRIPTION
## Summary
- ensure our Docker builds install patched npm/glob/brace-expansion and assert the versions so Trivy no longer flags the toolchain
- upgrade prisma/@prisma/client/@prisma/dev/@prisma/adapter-pg to 7.0.1 and force valibot@1.2.0 to clear the HIGH advisories caught by npm audit
- regenerate package-lock to apply the overrides and keep workspace clean

## Testing
- [x] npm audit --audit-level=moderate
- [x] npx tsc -p libs/database/tsconfig.json