### PR TITLE
feat(docs): enforce docs process in workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -131,6 +131,36 @@ body:
         - Performance considerations: ...
         - Security implications: ...
 
+  - type: markdown
+    attributes:
+      value: |
+        ## 📚 Documentation Requirements
+
+        Features should ship with documentation updates where appropriate.
+        See documentation standards: `apps/docs/docs/contributing/documentation-standards.md`.
+
+  - type: checkboxes
+    id: docs_requirements
+    attributes:
+      label: Documentation Requirements
+      description: What documentation updates are expected for this feature?
+      options:
+        - label: User-facing docs (guides, getting started, or reference in `apps/docs/docs/**` or `docs/**`)
+        - label: API docs (`apps/docs/docs/api/**` or OpenAPI)
+        - label: ADR for architectural decisions (`apps/docs/docs/reference/adr/**` or `adr/**`)
+        - label: Deployment / operations docs (`apps/docs/DEPLOYMENT.md` or deployment guides)
+        - label: No docs changes required (N/A) – explain why below
+
+  - type: textarea
+    id: docs_notes
+    attributes:
+      label: Documentation Notes
+      description: Describe what documentation will be added/updated (or why no docs are needed).
+      placeholder: |
+        - Affected docs:
+        - New sections/pages:
+        - Links to related ADRs or guides:
+
   - type: checkboxes
     id: contribution
     attributes:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,98 @@
+<!--
+Thank you for contributing to Anchorpipe! 🎉
+Please fill out this template to help us review your PR efficiently.
+-->
+
+## 📝 Description
+
+<!-- Provide a clear and concise description of your changes -->
+
+### What does this PR do?
+
+<!-- Describe the changes and their purpose -->
+
+### Why is this change needed?
+
+<!-- Explain the motivation or problem this PR solves -->
+
+## 🔗 Related Issues
+
+<!-- Link to related issues using keywords: Fixes #123, Closes #456, Relates to #789 -->
+
+Fixes #
+
+## 🧾 Type of Change
+
+<!-- Check all that apply -->
+
+- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
+- [ ] ✨ New feature (non-breaking change that adds functionality)
+- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] 📚 Documentation update / docs-only change
+- [ ] 🎨 Style/UI change
+- [ ] ♻️ Code refactoring
+- [ ] ⚡ Performance improvement
+- [ ] ✅ Test update
+- [ ] 🔧 Build/CI configuration change
+- [ ] 🔒 Security fix
+
+## 📚 Documentation Checklist
+
+<!--
+For feature and behavior changes, ensure documentation is updated.
+See documentation standards: apps/docs/docs/contributing/documentation-standards.md
+-->
+
+- [ ] User-facing docs updated (e.g. `apps/docs/docs/**` or `docs/**`)
+- [ ] API docs updated (`apps/docs/docs/api/**` or OpenAPI as needed)
+- [ ] ADR added/updated for architecture decisions (`apps/docs/docs/reference/adr/**` or `adr/**`)
+- [ ] Deployment docs updated (`apps/docs/DEPLOYMENT.md` or related guides), if applicable
+- [ ] Docs not required for this change (N/A) — explanation provided below
+
+**If docs are N/A, explain why:**
+
+>
+
+## 🧪 Testing
+
+<!-- Describe the tests you ran and how to reproduce them -->
+
+### How has this been tested?
+
+- [ ] Unit tests
+- [ ] Integration tests
+- [ ] E2E tests
+- [ ] Manual testing
+
+### Test Configuration
+
+- **OS**:
+- **Node version / Browser**:
+- **Test environment**:
+
+## ✅ Checklist
+
+### Code Quality
+
+- [ ] My code follows the project's style guidelines
+- [ ] I have performed a self-review of my code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] My changes generate no new warnings or errors
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing tests pass locally with my changes
+
+### Documentation
+
+- [ ] I reviewed the [documentation standards](apps/docs/docs/contributing/documentation-standards.md)
+- [ ] I updated relevant docs (user guides, reference, or ADRs) for this change
+- [ ] I verified `npm run validate:docs` passes (or is not required for this PR)
+
+### Security & Performance
+
+- [ ] I have checked for security vulnerabilities and input validation issues
+- [ ] I have considered performance implications and budgets
+- [ ] I have documented any breaking changes
+
+## 📊 Additional Context
+
+<!-- Add any other context about the PR here (screenshots, tradeoffs, rollout plan, etc.) -->

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -37,6 +37,36 @@ jobs:
             echo "This is a warning, not a blocker."
           fi
 
+          # Enforce docs for feature PRs
+          echo "Checking documentation expectations for feature PRs..."
+          PR_LABELS="$(jq -r '.pull_request.labels[].name // empty' "$GITHUB_EVENT_PATH")"
+          if echo "$PR_LABELS" | grep -qx 'type:feature'; then
+            BASE_SHA="$(jq -r '.pull_request.base.sha' "$GITHUB_EVENT_PATH")"
+            CHANGED_FILES="$(git diff --name-only "$BASE_SHA"...HEAD || true)"
+
+            DOCS_CHANGED="$(echo "$CHANGED_FILES" | grep -E '^(apps/docs/docs/|docs/|adr/)' || true)"
+
+            if [ -z "$DOCS_CHANGED" ]; then
+              echo "❌ This PR is labeled 'type:feature' but no documentation files were changed."
+              echo "Expected updates in one or more of:"
+              echo "  - apps/docs/docs/** or docs/** (user / reference docs)"
+              echo "  - apps/docs/docs/api/** or OpenAPI (API docs)"
+              echo "  - adr/** or apps/docs/docs/reference/adr/** (architecture decisions)"
+              echo ""
+              echo "If docs are truly not required, either:"
+              echo "  - Add a short explanation under 'Documentation Checklist' in the PR body, OR"
+              echo "  - Adjust labels if this is not a feature change."
+              echo ""
+              echo "See documentation standards at: apps/docs/docs/contributing/documentation-standards.md"
+              exit 1
+            else
+              echo "✅ Feature PR includes documentation changes:"
+              echo "$DOCS_CHANGED"
+            fi
+          else
+            echo "Skipping docs-enforcement: PR is not labeled type:feature."
+          fi
+
           echo "✅ PR validation checks complete"
 
       - name: Check branch name

--- a/apps/docs/docs/contributing/documentation-standards.md
+++ b/apps/docs/docs/contributing/documentation-standards.md
@@ -1,0 +1,134 @@
+# Documentation Standards
+
+This guide describes how to write and maintain documentation for Anchorpipe.
+It applies to content in `apps/docs/docs/**`, `docs/**`, and `adr/**`.
+
+## Goals
+
+- Make it easy for users and contributors to understand and use the product.
+- Keep docs consistent in structure, tone, and formatting.
+- Ensure features ship with the right documentation updates.
+
+## File Format and Location
+
+- **Format**: Markdown (`.md`) or MDX (`.mdx`) for Docusaurus content.
+- **Locations**:
+  - Product docs: `apps/docs/docs/**`
+  - Repo-level docs: `docs/**`
+  - Architecture decision records: `adr/**` and `apps/docs/docs/reference/adr/**`
+- **Naming**:
+  - Use `kebab-case` for filenames (e.g. `getting-started.md`, `rate-limiting.md`).
+  - Keep names short and descriptive.
+
+## Structure
+
+For most guides and reference docs:
+
+- Start with a top-level heading (`# Title`).
+- Provide a short **Overview** section that explains:
+  - What this page covers.
+  - Who it is for.
+  - When you should use it.
+- Use clear sections with `##` and `###` headings.
+- Prefer lists and tables over long paragraphs when summarizing options.
+
+### Common Sections
+
+Depending on the doc type, include some of:
+
+- **Overview** – What and why.
+- **Prerequisites** – What the reader needs before starting.
+- **Steps / How-to** – Numbered steps for tasks.
+- **Configuration** – Options, flags, environment variables.
+- **Examples** – Code samples or request/response examples.
+- **Troubleshooting** – Common issues and how to fix them.
+- **Further Reading** – Links to related docs and ADRs.
+
+## Markdown Style
+
+These rules align with the repo’s markdownlint configuration:
+
+- Wrap lines at **≤120 characters** where practical.
+- Use fenced code blocks with a language:
+
+```bash
+npm run docs:dev
+```
+
+- Surround code fences with blank lines.
+- Avoid bare URLs in text:
+  - ✅ `See [Vercel docs](https://vercel.com/docs).`
+  - ❌ `See https://vercel.com/docs`
+- Use emphasis for meaning, not headings:
+  - ✅ `## Configuration`
+  - ❌ `**Configuration**` as a pseudo-heading.
+
+Inline HTML is allowed where Docusaurus needs it, but keep it minimal and documented.
+
+## Code Examples
+
+When including code examples:
+
+- Use realistic, copy-pasteable examples.
+- Show both request and response for API examples.
+- Include error handling when it matters for production use.
+- Keep examples in sync with the current APIs and configuration.
+
+For REST APIs:
+
+- Link to or reference the OpenAPI definition when relevant.
+- Use consistent base URLs and common headers.
+
+## Links
+
+- Prefer **relative links** within the docs site:
+  - `../getting-started/installation.md`
+  - `./configuration.md`
+- Use descriptive link text (what the user will get), not “click here”.
+- Keep anchors stable (avoid changing heading text unless necessary).
+
+## ADR Standards
+
+Architecture Decision Records live in:
+
+- `adr/**` (source of truth in the repo).
+- `apps/docs/docs/reference/adr/**` (published in the docs site).
+
+Each ADR should:
+
+- Follow the existing ADR template (context, decision, consequences).
+- Have a stable numeric identifier (`0001-...`, `0002-...`).
+- Link to related ADRs and implementation docs.
+- Be updated or superseded when decisions change, rather than silently edited.
+
+## When to Update Docs
+
+Update documentation when:
+
+- Adding or changing a feature or behavior.
+- Modifying APIs, request/response shapes, or auth.
+- Changing configuration, environment variables, or deployment flows.
+- Introducing or updating an ADR.
+- Deprecating or removing functionality.
+
+For small internal refactors with no user-visible change, document only if it affects
+internal runbooks or ADRs.
+
+## PR Expectations
+
+For feature PRs (especially those labeled `type:feature`):
+
+- Include at least one of:
+  - Updated user docs in `apps/docs/docs/**` or `docs/**`.
+  - Updated API docs.
+  - New or updated ADR.
+  - An explicit, documented reason why docs are not required.
+- Run `npm run validate:docs` when you touch docs to catch:
+  - Markdown style issues.
+  - Spelling issues.
+  - Broken links (via Docusaurus build).
+
+Refer back to this page from:
+
+- `.github/PULL_REQUEST_TEMPLATE.md` (documentation checklist).
+- `.github/ISSUE_TEMPLATE/feature.yml` (documentation requirements).


### PR DESCRIPTION
## Summary
Implements STORY-004 by embedding documentation requirements into the workflow and CI:

- Replaces the PR template with one that includes a documentation checklist and references the docs standards.
- Updates the feature issue template to capture documentation expectations whenever a story is created.
- Adds a documentation-standards guide under `apps/docs/docs/contributing/` covering structure, style, ADR expectations, and when to update docs.
- Extends the `pr-validation` workflow so PRs labeled `type:feature` fail if no docs files were changed (unless the author explicitly justifies it in the checklist).

## Testing
- `npm run lint`
- `npm run format:check`

## Issue
- STORY-004 – Integrate Documentation into Development Workflow